### PR TITLE
Prevent crashes for null legacy records

### DIFF
--- a/lib/ecto_ranked.ex
+++ b/lib/ecto_ranked.ex
@@ -168,6 +168,9 @@ defmodule EctoRanked do
     case results do
       [] -> {get_current_last(cs, options), @max}
       [lower] -> {lower, @max}
+      [nil, nil] ->
+        rebalance_ranks(cs, options)
+        find_neighbors(cs, options, position)
       [lower, upper] -> {lower, upper}
     end
   end

--- a/test/ranked_test.exs
+++ b/test/ranked_test.exs
@@ -176,6 +176,48 @@ defmodule EctoRanked.RankedTest do
     end
   end
 
+  describe "legacy records" do
+    test "new record can be inserted" do
+      model1 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+      model2 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+      model3 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+
+      # reset models to uninitialized rank
+      Model |> Repo.update_all(set: [my_rank: nil])
+
+      model4 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+      assert ranked_ids() == [model4.id, model1.id, model2.id, model3.id]
+    end
+
+    test "new record can be positioned" do
+      model1 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+      model2 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+      model3 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+
+      # reset models to uninitialized rank
+      Model |> Repo.update_all(set: [my_rank: nil])
+
+      model4 = %Model{} |> Model.changeset(%{my_position: 1}) |> Repo.insert!
+      assert ranked_ids() == [model1.id, model4.id, model2.id, model3.id]
+    end
+
+    test "additional records placed after ranked records" do
+      _model1 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+      _model2 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
+
+      # reset models to uninitialized rank
+      Model |> Repo.update_all(set: [my_rank: nil])
+
+      _model3 = %Model{} |> Model.changeset(%{my_position: 0}) |> Repo.insert!
+      generated_ranks = ranked_ids()
+      model4 = %Model{} |> Model.changeset(%{my_position: 0}) |> Repo.insert!
+      model5 = %Model{} |> Model.changeset(%{my_position: 0}) |> Repo.insert!
+
+      assert ranked_ids() == [model5.id, model4.id] ++ generated_ranks
+    end
+
+  end
+
   describe "rebalancing" do
     test "rebalancing lots of items stays in the proper order" do
       models = Enum.map(1..100, fn(item) ->


### PR DESCRIPTION
Add ability for legacy records (null ranked) to generate ranks generically without error. Then allow records to be placed by position.