### PR TITLE
Fix ArithmeticError when moving moving only item in its scope

### DIFF
--- a/lib/ecto_ranked.ex
+++ b/lib/ecto_ranked.ex
@@ -198,6 +198,10 @@ defmodule EctoRanked do
     |> limit(1)
     |> select([m], field(m, ^options.rank_field))
     |> cs.repo.one(prefix: options.prefix)
+    |> case do
+      nil -> @min
+      min -> min
+    end
   end
 
   defp find_prev_two(cs, options) do

--- a/test/prefixed_test.exs
+++ b/test/prefixed_test.exs
@@ -72,6 +72,12 @@ defmodule EctoRanked.PrefixedTest do
       assert model.my_rank == updated.my_rank
     end
 
+    test "moving an item when its the only one in its scope" do
+      model = %Model{} |> Model.changeset(%{}) |> insert
+      updated = model |> Model.changeset(%{my_position: 1}) |> update
+      assert updated.my_rank == 0
+    end
+
     test "moving an item up to a specific position" do
       model1 = %Model{} |> Model.changeset(%{}) |> insert
       model2 = %Model{} |> Model.changeset(%{}) |> insert

--- a/test/ranked_test.exs
+++ b/test/ranked_test.exs
@@ -68,6 +68,12 @@ defmodule EctoRanked.RankedTest do
       assert model.my_rank == updated.my_rank
     end
 
+    test "moving an item when its the only one in its scope" do
+      model = %Model{} |> Model.changeset(%{}) |> Repo.insert!()
+      updated = model |> Model.changeset(%{my_position: 1}) |> Repo.update!()
+      assert updated.my_rank == 0
+    end
+
     test "moving an item up to a specific position" do
       model1 = %Model{} |> Model.changeset(%{}) |> Repo.insert!
       model2 = %Model{} |> Model.changeset(%{}) |> Repo.insert!


### PR DESCRIPTION
I noticed ecto_ranked would throw a ArithmeticError when trying to `set_rank()` on a record that is the only one in its scope. ☺️